### PR TITLE
feat(asc-viewer-cli): add MCP server for AI assistant integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Development Commands
+
+```bash
+# Build
+npm run build                    # Build asc-cli
+npm run build:all               # Build all apps (asc-cli, asc-viewer, asc-viewer-cli)
+npm run build:viewer-cli        # Build asc-viewer and asc-viewer-cli together
+
+# Development
+npm run viewer:dev              # Run asc-viewer dev server
+npm run viewer-cli:dev          # Run asc-viewer-cli in dev mode (uses --dev flag)
+npm run build:watch             # Watch mode for asc-cli
+npx nx mcp asc-viewer-cli       # Run MCP server in dev mode
+
+# Test
+npm run test                    # Run all tests once
+npm run test:watch              # Run tests in watch mode
+npm run test:ui                 # Run tests with Vitest UI
+
+# Lint
+npm run lint                    # Run ESLint on all projects
+
+# Release
+npm run release-all:dry-run     # Dry run multi-package semantic release
+npm run release-all             # Release all packages
+```
+
+## Project Structure
+
+This is an Nx monorepo with three main applications and two library packages:
+
+### Apps
+- **asc-cli** (`apps/asc-cli`): CLI that generates JSON Canvas files for Recoil state visualization. Entry: `atomic-state-canvas` command.
+- **asc-viewer** (`apps/asc-viewer`): React web app for 2D/3D visualization using react-force-graph. Uses Jotai for state, Tailwind for styling.
+- **asc-viewer-cli** (`apps/asc-viewer-cli`): CLI that starts a Vite dev server, watches `.asc.` files, and serves the viewer. Also includes MCP server for AI assistant integration. Entry: `asc-viewer` command with subcommands `serve` (default) and `mcp`.
+
+### Libs
+- **core** (`libs/core`): Core parsing and graph logic - AST parsing with oxc-parser, graph data structures, layout algorithms, cycle detection.
+- **asc-viewer-libs** (`libs/asc-viewer-libs`): Shared types and utilities for the viewer.
+
+## Architecture
+
+### Core Parsing Flow (`libs/core`)
+1. **graphUtils.ts**: Reads files, parses AST with oxc-parser, walks with acorn-walk to extract imports and Recoil declarations
+2. **plugins/recoil.ts**: Plugin that identifies `atom`, `selector`, `atomFamily`, `selectorFamily` calls and extracts dependencies from `get()` calls
+3. **core.ts**: `generateAtomicStateGraph()` builds a dependency graph from an entry file/variable
+4. **dataStructure.ts**: `Graph` class maintains adjacency list, edge map, and generates level topology for layout
+5. **cycleDetection/index.ts**: DFS-based cycle detection for self-references and cyclic dependencies
+6. **graphLayout/**: Two layout algorithms - `SIMPLE_TOPOLOGY` (level-based) and `FORCE_DIRECTED` (d3-force)
+
+### asc-viewer-cli Flow
+1. Loads config via cosmiconfig (`.ascrc`, `asc.config.js`, etc.)
+2. Uses chokidar to watch for `.asc.` files
+3. Generates metadata JSON files in `.atomic-state-canvas/` directory
+4. Starts Vite server with custom middleware to serve metadata at `/.atomic-state-canvas`
+
+### MCP Server (`apps/asc-viewer-cli/src/mcp/`)
+The MCP server enables AI assistants to interact with the codebase analysis tools:
+- **index.ts**: Server setup using `@modelcontextprotocol/sdk` with stdio transport
+- **tools.ts**: Defines 4 MCP tools (`analyze_state`, `find_cycles`, `list_atoms`, `launch_viewer`) with Zod schemas
+- **viewer.ts**: Extracted viewer launcher logic for reuse by both CLI and MCP
+
+### Plugin System
+The `TPluginConfig` interface in `libs/core/src/types.ts` defines how to parse AST nodes for different state libraries. Currently only Recoil is implemented via `libs/core/src/plugins/recoil.ts`.
+
+## Key Patterns
+
+- Uses oxc-parser for fast TypeScript/JavaScript parsing
+- Uses acorn-walk for AST traversal (with mock handlers for TS-specific nodes like `TSAsExpression`)
+- Graph output follows [JSON Canvas](https://jsoncanvas.org/) spec for Obsidian compatibility
+- Config uses cosmiconfig pattern: `.ascrc.json`, `asc.config.js`, `asc.config.ts`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,32 @@ This is a mono-repository that contains a collection of applications for analyzi
 | Application    | Description                                                                                                                                                                                                                              | Installation                                       |
 |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
 | [asc-cli](./apps/asc-cli)        | CLI tool for visualizing atomic state relationships. It visualizes atomic state relationships using [JSON Canvas](https://jsoncanvas.org/)                                                                                               | npm install @atomic-state-canvas/asc-cli -g        |
-| [asc-viewer-cli](./apps/asc-viewer-cli) | An interactive web application for analyzing and visualizing atomic state relationships. By launching the development tool, it looks for ".asc." files in the directory and automatically populates the atomic graphs in a "Storybook"-like experience. | npm install @atomic-state-canvas/asc-viewer-cli -D |
+| [asc-viewer-cli](./apps/asc-viewer-cli) | An interactive web application for analyzing and visualizing atomic state relationships. By launching the development tool, it looks for ".asc." files in the directory and automatically populates the atomic graphs in a "Storybook"-like experience. Also includes MCP server for AI assistant integration. | npm install @atomic-state-canvas/asc-viewer-cli -D |
+
+## Configuration (asc-viewer-cli)
+
+The viewer CLI uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) for configuration. Create a config file in your project root:
+
+**Supported files:** `.ascrc.json`, `.ascrc.js`, `.ascrc.yaml`, `asc.config.js`, `asc.config.ts`
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `watchDir` | `string` | `"src"` | Directory to watch for `.asc.` files |
+| `port` | `number` | `1296` | Port to run the viewer server on |
+| `extensions` | `string[]` | `[".asc.js", ".asc.ts"]` | File extensions to watch |
+| `excludePatternInGlob` | `string` | `undefined` | Glob pattern to exclude files |
+
+### Example `.ascrc.json`
+```json
+{
+  "watchDir": "./src",
+  "port": 3000,
+  "extensions": [".asc.ts"],
+  "excludePatternInGlob": "*.test.ts"
+}
+```
 
 ## Use Cases
 
@@ -25,6 +50,33 @@ Visualize atomic state relationships in 2D.
 
 Visualize atomic state relationships in 3D.
 ![asc viewer - 3d](./assets/asc-viewer-3d.png)
+
+## MCP Server (AI Assistant Integration)
+
+The `asc-viewer-cli` includes an MCP (Model Context Protocol) server that enables AI assistants like Claude to analyze your Recoil state and launch visualizations.
+
+### Setup
+
+Add to your Claude Code config (`.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "atomic-state-canvas": {
+      "command": "npx",
+      "args": ["@atomic-state-canvas/asc-viewer-cli", "mcp"]
+    }
+  }
+}
+```
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `analyze_state` | Generate dependency graph from entry file/variable |
+| `find_cycles` | Detect cyclic dependencies and self-references |
+| `list_atoms` | List all atoms/selectors in a file with dependencies |
+| `launch_viewer` | Start the visualization server |
 
 ## Roadmap
 - [ ] Support more state management libraries such as [Jotai](https://jotai.org/)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add to your Claude Code config (`.mcp.json`):
 | `analyze_state` | Generate dependency graph from entry file/variable |
 | `find_cycles` | Detect cyclic dependencies and self-references |
 | `list_atoms` | List all atoms/selectors in a file with dependencies |
-| `launch_viewer` | Start the visualization server |
+| `launch_viewer` | Get command instructions to start the visualization server |
 
 ## Roadmap
 - [ ] Support more state management libraries such as [Jotai](https://jotai.org/)

--- a/apps/asc-viewer-cli/README.md
+++ b/apps/asc-viewer-cli/README.md
@@ -85,4 +85,11 @@ Add to your Claude Code config (`.mcp.json`):
 | `analyze_state` | Generate dependency graph from entry file/variable |
 | `find_cycles` | Detect cyclic dependencies and self-references |
 | `list_atoms` | List all atoms/selectors in a file with dependencies |
-| `launch_viewer` | Start the visualization server |
+| `launch_viewer` | Get command instructions to start the visualization server |
+
+#### MCP Inspector
+
+Start the MCP inspector for debugging and visualization:
+```bash
+npx @modelcontextprotocol/inspector node dist/asc-viewer-cli/index.js mcp
+```

--- a/apps/asc-viewer-cli/README.md
+++ b/apps/asc-viewer-cli/README.md
@@ -5,7 +5,84 @@ An interactive web application for analyzing and visualizing atomic state relati
 ## Installation
 ```bash
 npm install @atomic-state-canvas/asc-viewer-cli -D
-
-# Start the viewer
-npx asc-viewer-cli
 ```
+
+## Configuration
+
+The CLI uses [cosmiconfig](https://github.com/cosmiconfig/cosmiconfig) for configuration. Create one of the following files in your project root:
+
+- `.ascrc.json`
+- `.ascrc.js`
+- `.ascrc.yaml`
+- `asc.config.js`
+- `asc.config.ts`
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `watchDir` | `string` | `"src"` | Directory to watch for `.asc.` files |
+| `port` | `number` | `1296` | Port to run the viewer server on |
+| `extensions` | `string[]` | `[".asc.js", ".asc.ts"]` | File extensions to watch |
+| `excludePatternInGlob` | `string` | `undefined` | Glob pattern to exclude files |
+
+### Example Configuration
+
+`.ascrc.json`:
+```json
+{
+  "watchDir": "./src",
+  "port": 3000,
+  "extensions": [".asc.ts"],
+  "excludePatternInGlob": "*.test.ts"
+}
+```
+
+`asc.config.js`:
+```js
+module.exports = {
+  watchDir: './src/stores',
+  port: 1296,
+  extensions: ['.asc.ts', '.asc.js'],
+  excludePatternInGlob: '**/*.test.*'
+};
+```
+
+## Usage
+
+### Start the Viewer
+```bash
+# Start the viewer (default command)
+npx asc-viewer
+
+# With options
+npx asc-viewer serve --port 3000 --watch-dir ./src
+```
+
+### MCP Server (AI Assistant Integration)
+
+Start the MCP server for AI assistant integration:
+```bash
+npx asc-viewer mcp
+```
+
+Add to your Claude Code config (`.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "atomic-state-canvas": {
+      "command": "npx",
+      "args": ["@atomic-state-canvas/asc-viewer-cli", "mcp"]
+    }
+  }
+}
+```
+
+#### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `analyze_state` | Generate dependency graph from entry file/variable |
+| `find_cycles` | Detect cyclic dependencies and self-references |
+| `list_atoms` | List all atoms/selectors in a file with dependencies |
+| `launch_viewer` | Start the visualization server |

--- a/apps/asc-viewer-cli/project.json
+++ b/apps/asc-viewer-cli/project.json
@@ -43,6 +43,13 @@
         "command": "tsx apps/asc-viewer-cli/src/index.ts --dev",
         "cwd": "."
       }
+    },
+    "mcp": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsx apps/asc-viewer-cli/src/index.ts mcp",
+        "cwd": "."
+      }
     }
   }
 }

--- a/apps/asc-viewer-cli/src/index.ts
+++ b/apps/asc-viewer-cli/src/index.ts
@@ -6,7 +6,7 @@ import { startMcpServer } from './mcp/index';
 
 const program = new Command();
 
-program.name('asc-viewer').description('Atomic State Canvas Viewer CLI').version('0.0.1');
+program.name('asc-viewer').description('Atomic State Canvas Viewer CLI');
 
 // Default command - launch viewer (serve)
 program

--- a/apps/asc-viewer-cli/src/index.ts
+++ b/apps/asc-viewer-cli/src/index.ts
@@ -1,121 +1,47 @@
 #!/usr/bin/env node
+import { Command } from 'commander';
 import { logMsg } from '@atomic-state-canvas/core';
-import chokidar from 'chokidar';
-import { cosmiconfig } from 'cosmiconfig';
-import path from 'path';
-import fs from 'fs';
-import { createServer, PluginOption } from 'vite';
-import {
-  DEFAULT_EXTENSIONS,
-  DEFAULT_METADATA_DIR_NAME,
-  DEFAULT_PORT,
-  DEFAULT_WATCH_DIR
-} from './constants';
-import { IAscConfig } from '@atomic-state-canvas/asc-viewer-libs';
-import { loadConfig } from './configUtils';
-import { generateMetadata } from './metadataUtils';
+import { launchViewer } from './mcp/viewer';
+import { startMcpServer } from './mcp/index';
 
-const explorer = cosmiconfig('asc');
+const program = new Command();
 
-const isDev = process.argv.includes('--dev');
+program.name('asc-viewer').description('Atomic State Canvas Viewer CLI').version('0.0.1');
 
-const checkAndClearFolder = (folderPath: string) => {
-  try {
-    if (fs.existsSync(folderPath)) {
-      const files = fs.readdirSync(folderPath);
-
-      for (const file of files) {
-        const filePath = path.join(folderPath, file);
-        const stat = fs.statSync(filePath);
-
-        if (stat.isDirectory()) {
-          // Recursively delete subdirectories
-          fs.rmdirSync(filePath, { recursive: true });
-        } else {
-          // Delete files
-          fs.unlinkSync(filePath);
-        }
-      }
-      logMsg(`Folder "${folderPath}" cleared successfully.`);
-    } else {
-      logMsg(`Folder "${folderPath}" does not exist.`);
-    }
-  } catch (error) {
-    console.error(`An error occurred: ${error}`);
-  }
-};
-
-const watchAndGenerateMetadata = (params: {
-  watchDir: string;
-  extensions: string[];
-  excludePatternInGlob: string | undefined;
-}) => {
-  const { watchDir, extensions, excludePatternInGlob } = params;
-  checkAndClearFolder(DEFAULT_METADATA_DIR_NAME);
-  logMsg(`Setting up file watcher on ${watchDir}`);
-  const watcher = chokidar.watch(watchDir, {
-    ignored: (path, stats) => {
-      if (path.includes(DEFAULT_METADATA_DIR_NAME)) {
-        return true;
-      }
-      return stats?.isFile() && !extensions.some((ext) => path.endsWith(ext));
-    }
-  });
-  watcher.on('add', (path) => generateMetadata(path, excludePatternInGlob));
-  watcher.on('change', (path) => generateMetadata(path, excludePatternInGlob));
-};
-
-const customPlugin = (): PluginOption => {
-  return {
-    name: 'configure-server',
-    configureServer(server) {
-      server.middlewares.use('/.atomic-state-canvas', async (req, res) => {
-        const fs = await import('fs/promises');
-        const path = await import('path');
-        try {
-          const files = await fs.readdir(DEFAULT_METADATA_DIR_NAME);
-          const data = await Promise.all(
-            files.map(async (f) =>
-              JSON.parse(await fs.readFile(path.join(DEFAULT_METADATA_DIR_NAME, f), 'utf-8'))
-            )
-          );
-          res.setHeader('Content-Type', 'application/json');
-          res.end(JSON.stringify(data));
-        } catch (err) {
-          console.error(err);
-          res.end(JSON.stringify([]));
-        }
+// Default command - launch viewer (serve)
+program
+  .command('serve', { isDefault: true })
+  .description('Start the Atomic State Canvas viewer server')
+  .option('-p, --port <port>', 'Port to run the viewer on')
+  .option('-w, --watch-dir <dir>', 'Directory to watch for .asc files')
+  .option('--dev', 'Run in development mode')
+  .action(async (options: { port?: string; watchDir?: string; dev?: boolean }) => {
+    try {
+      const result = await launchViewer({
+        port: options.port ? parseInt(options.port, 10) : undefined,
+        watchDir: options.watchDir,
+        isDev: options.dev
       });
+      logMsg(
+        `Atomic State Canvas Viewer running at ${result.url} (${options.dev ? 'dev' : 'prod'} mode)`
+      );
+    } catch (error) {
+      console.error('Failed to start viewer:', error);
+      process.exit(1);
     }
-  };
-};
-
-async function main() {
-  const config: IAscConfig = await loadConfig(explorer);
-  const {
-    port = DEFAULT_PORT,
-    watchDir = path.resolve(process.cwd(), DEFAULT_WATCH_DIR),
-    extensions = DEFAULT_EXTENSIONS,
-    excludePatternInGlob
-  } = config;
-  const viewerPath = isDev
-    ? path.resolve(process.cwd(), 'apps/asc-viewer')
-    : path.resolve(__dirname, 'asc-viewer');
-
-  const server = await createServer({
-    root: viewerPath,
-    server: {
-      port
-    },
-    plugins: [customPlugin()]
   });
-  // TODO: Add server.restart() to watcher
-  watchAndGenerateMetadata({ watchDir, extensions, excludePatternInGlob });
 
-  await server.listen();
-  logMsg(
-    `🚀 Atomic State Canvas Viewer running at http://localhost:${port} (${isDev ? 'dev' : 'prod'} mode)`
-  );
-}
+// MCP subcommand
+program
+  .command('mcp')
+  .description('Start the MCP server for AI assistant integration')
+  .action(async () => {
+    try {
+      await startMcpServer();
+    } catch (error) {
+      console.error('Failed to start MCP server:', error);
+      process.exit(1);
+    }
+  });
 
-void main();
+program.parse();

--- a/apps/asc-viewer-cli/src/mcp/index.ts
+++ b/apps/asc-viewer-cli/src/mcp/index.ts
@@ -1,10 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema
-} from '@modelcontextprotocol/sdk/types.js';
-import { tools, handleToolCall } from './tools';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { handleToolCall, tools } from './tools';
 
 const server = new Server(
   {
@@ -19,7 +16,7 @@ const server = new Server(
 );
 
 // Register tool listing handler
-server.setRequestHandler(ListToolsRequestSchema, async () => {
+server.setRequestHandler(ListToolsRequestSchema, () => {
   return { tools };
 });
 

--- a/apps/asc-viewer-cli/src/mcp/index.ts
+++ b/apps/asc-viewer-cli/src/mcp/index.ts
@@ -1,0 +1,36 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
+import { tools, handleToolCall } from './tools';
+
+const server = new Server(
+  {
+    name: 'atomic-state-canvas',
+    version: '1.0.0'
+  },
+  {
+    capabilities: {
+      tools: {}
+    }
+  }
+);
+
+// Register tool listing handler
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return { tools };
+});
+
+// Register tool call handler
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  return handleToolCall(request.params.name, request.params.arguments);
+});
+
+export async function startMcpServer(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // Use stderr for logging since stdout is reserved for MCP protocol
+  console.error('Atomic State Canvas MCP server started on stdio');
+}

--- a/apps/asc-viewer-cli/src/mcp/tools.ts
+++ b/apps/asc-viewer-cli/src/mcp/tools.ts
@@ -1,0 +1,237 @@
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import {
+  generateAtomicStateGraph,
+  findAllCycles,
+  getFileDetailsGivenFramework
+} from '@atomic-state-canvas/core';
+import { launchViewer } from './viewer';
+
+// Tool schemas
+const analyzeStateSchema = z.object({
+  entryFile: z.string().describe('Absolute path to the entry file containing the state'),
+  entryVariable: z.string().describe('Name of the atom/selector variable to analyze'),
+  framework: z.enum(['recoil']).default('recoil').describe('State management framework'),
+  excludePattern: z.string().optional().describe('Glob pattern to exclude files')
+});
+
+const findCyclesSchema = z.object({
+  entryFile: z.string().describe('Absolute path to the entry file'),
+  entryVariable: z.string().describe('Name of the atom/selector variable'),
+  framework: z.enum(['recoil']).default('recoil').describe('State management framework'),
+  excludePattern: z.string().optional().describe('Glob pattern to exclude files')
+});
+
+const listAtomsSchema = z.object({
+  filePath: z.string().describe('Absolute path to the file to analyze'),
+  framework: z.enum(['recoil']).default('recoil').describe('State management framework'),
+  excludePattern: z.string().optional().describe('Glob pattern to exclude files')
+});
+
+const launchViewerSchema = z.object({
+  port: z.number().optional().default(1296).describe('Port to run the viewer on'),
+  watchDir: z.string().optional().describe('Directory to watch for .asc files')
+});
+
+// Tool definitions for MCP
+export const tools = [
+  {
+    name: 'analyze_state',
+    description:
+      'Generate a dependency graph from an entry file and variable. Returns the graph structure with nodes and edges showing state dependencies.',
+    inputSchema: zodToJsonSchema(analyzeStateSchema)
+  },
+  {
+    name: 'find_cycles',
+    description:
+      'Detect cyclic dependencies in state management code. Returns information about self-references and cyclic dependency chains.',
+    inputSchema: zodToJsonSchema(findCyclesSchema)
+  },
+  {
+    name: 'list_atoms',
+    description:
+      'List all atoms and selectors in a file with their dependencies. Useful for understanding what state is defined in a specific file.',
+    inputSchema: zodToJsonSchema(listAtomsSchema)
+  },
+  {
+    name: 'launch_viewer',
+    description:
+      'Start the Atomic State Canvas web viewer for visual exploration of state dependencies. Opens an interactive 2D/3D visualization.',
+    inputSchema: zodToJsonSchema(launchViewerSchema)
+  }
+];
+
+type ToolResult = {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+};
+
+// Tool implementation handlers
+export async function handleToolCall(toolName: string, args: unknown): Promise<ToolResult> {
+  try {
+    switch (toolName) {
+      case 'analyze_state':
+        return analyzeState(analyzeStateSchema.parse(args));
+      case 'find_cycles':
+        return findCyclesHandler(findCyclesSchema.parse(args));
+      case 'list_atoms':
+        return listAtoms(listAtomsSchema.parse(args));
+      case 'launch_viewer':
+        return await launchViewerHandler(launchViewerSchema.parse(args));
+      default:
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Unknown tool: ${toolName}` }]
+        };
+    }
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: `Error: ${error instanceof Error ? error.message : String(error)}`
+        }
+      ]
+    };
+  }
+}
+
+// analyze_state implementation
+function analyzeState(args: z.infer<typeof analyzeStateSchema>): ToolResult {
+  const { entryFile, entryVariable, framework, excludePattern } = args;
+
+  const { graph, entryNodeId } = generateAtomicStateGraph(entryFile, framework, {
+    searchVariableName: entryVariable,
+    excludePatternInGlob: excludePattern
+  });
+
+  const { nodeMap, getEdgeList } = graph.getInternalData();
+  const edges = getEdgeList();
+  const nodes = Array.from(nodeMap.values());
+
+  const result = {
+    entryNodeId,
+    totalNodes: nodes.length,
+    totalEdges: edges.length,
+    nodes: nodes.map((n) => ({
+      id: n.id,
+      name: n.name,
+      dependencies: n.dependencies
+    })),
+    edges: edges.map((e) => ({ from: e.source, to: e.target }))
+  };
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(result, null, 2)
+      }
+    ]
+  };
+}
+
+// find_cycles implementation
+function findCyclesHandler(args: z.infer<typeof findCyclesSchema>): ToolResult {
+  const { entryFile, entryVariable, framework, excludePattern } = args;
+
+  const { graph } = generateAtomicStateGraph(entryFile, framework, {
+    searchVariableName: entryVariable,
+    excludePatternInGlob: excludePattern
+  });
+
+  const { getEdgeList } = graph.getInternalData();
+  const edges = getEdgeList();
+  const { allCycles, cyclicStatsMap } = findAllCycles(edges);
+
+  const selfReferences = cyclicStatsMap.get('self-reference') || [];
+  const cyclicDeps = cyclicStatsMap.get('cyclic') || [];
+
+  const result = {
+    hasCycles: allCycles.length > 0,
+    totalCycles: allCycles.length,
+    selfReferences: {
+      count: selfReferences.length,
+      nodes: selfReferences.flat()
+    },
+    cyclicDependencies: {
+      count: cyclicDeps.length,
+      chains: cyclicDeps
+    }
+  };
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(result, null, 2)
+      }
+    ]
+  };
+}
+
+// list_atoms implementation
+function listAtoms(args: z.infer<typeof listAtomsSchema>): ToolResult {
+  const { filePath, framework, excludePattern } = args;
+  const excludeRegex = excludePattern ? new RegExp(excludePattern) : undefined;
+
+  const fileDetails = getFileDetailsGivenFramework(
+    filePath,
+    framework,
+    { excludePattern: excludeRegex },
+    { skipImport: false }
+  );
+
+  const result = {
+    filePath,
+    totalAtoms: fileDetails.presentNodes.length,
+    atoms: fileDetails.presentNodes.map((node) => ({
+      name: node.name,
+      id: node.id,
+      dependencies: node.dependencies,
+      dependencyCount: node.dependencies.length
+    })),
+    imports: fileDetails.importDetailsList.map((imp) => ({
+      variables: imp.importVariables,
+      from: imp.pathName,
+      type: imp.importType
+    }))
+  };
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(result, null, 2)
+      }
+    ]
+  };
+}
+
+// launch_viewer implementation
+async function launchViewerHandler(args: z.infer<typeof launchViewerSchema>): Promise<ToolResult> {
+  const { port, watchDir } = args;
+
+  try {
+    const result = await launchViewer({ port, watchDir });
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Atomic State Canvas Viewer started at ${result.url}`
+        }
+      ]
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: `Failed to launch viewer: ${error instanceof Error ? error.message : String(error)}`
+        }
+      ]
+    };
+  }
+}

--- a/apps/asc-viewer-cli/src/mcp/tools.ts
+++ b/apps/asc-viewer-cli/src/mcp/tools.ts
@@ -1,8 +1,7 @@
-import { z } from 'zod';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { toJSONSchema, z } from 'zod';
 import {
-  generateAtomicStateGraph,
   findAllCycles,
+  generateAtomicStateGraph,
   getFileDetailsGivenFramework
 } from '@atomic-state-canvas/core';
 import { launchViewer } from './viewer';
@@ -39,25 +38,25 @@ export const tools = [
     name: 'analyze_state',
     description:
       'Generate a dependency graph from an entry file and variable. Returns the graph structure with nodes and edges showing state dependencies.',
-    inputSchema: zodToJsonSchema(analyzeStateSchema)
+    inputSchema: toJSONSchema(analyzeStateSchema)
   },
   {
     name: 'find_cycles',
     description:
       'Detect cyclic dependencies in state management code. Returns information about self-references and cyclic dependency chains.',
-    inputSchema: zodToJsonSchema(findCyclesSchema)
+    inputSchema: toJSONSchema(findCyclesSchema)
   },
   {
     name: 'list_atoms',
     description:
       'List all atoms and selectors in a file with their dependencies. Useful for understanding what state is defined in a specific file.',
-    inputSchema: zodToJsonSchema(listAtomsSchema)
+    inputSchema: toJSONSchema(listAtomsSchema)
   },
   {
     name: 'launch_viewer',
     description:
       'Start the Atomic State Canvas web viewer for visual exploration of state dependencies. Opens an interactive 2D/3D visualization.',
-    inputSchema: zodToJsonSchema(launchViewerSchema)
+    inputSchema: toJSONSchema(launchViewerSchema)
   }
 ];
 

--- a/apps/asc-viewer-cli/src/mcp/viewer.ts
+++ b/apps/asc-viewer-cli/src/mcp/viewer.ts
@@ -1,0 +1,134 @@
+import { logMsg } from '@atomic-state-canvas/core';
+import chokidar from 'chokidar';
+import { cosmiconfig } from 'cosmiconfig';
+import path from 'path';
+import fs from 'fs';
+import { createServer, PluginOption, ViteDevServer } from 'vite';
+import {
+  DEFAULT_EXTENSIONS,
+  DEFAULT_METADATA_DIR_NAME,
+  DEFAULT_PORT,
+  DEFAULT_WATCH_DIR
+} from '../constants';
+import { IAscConfig } from '@atomic-state-canvas/asc-viewer-libs';
+import { loadConfig } from '../configUtils';
+import { generateMetadata } from '../metadataUtils';
+
+const explorer = cosmiconfig('asc');
+
+const checkAndClearFolder = (folderPath: string) => {
+  try {
+    if (fs.existsSync(folderPath)) {
+      const files = fs.readdirSync(folderPath);
+
+      for (const file of files) {
+        const filePath = path.join(folderPath, file);
+        const stat = fs.statSync(filePath);
+
+        if (stat.isDirectory()) {
+          fs.rmdirSync(filePath, { recursive: true });
+        } else {
+          fs.unlinkSync(filePath);
+        }
+      }
+      logMsg(`Folder "${folderPath}" cleared successfully.`);
+    } else {
+      logMsg(`Folder "${folderPath}" does not exist.`);
+    }
+  } catch (error) {
+    console.error(`An error occurred: ${error}`);
+  }
+};
+
+const watchAndGenerateMetadata = (params: {
+  watchDir: string;
+  extensions: string[];
+  excludePatternInGlob: string | undefined;
+}) => {
+  const { watchDir, extensions, excludePatternInGlob } = params;
+  checkAndClearFolder(DEFAULT_METADATA_DIR_NAME);
+  logMsg(`Setting up file watcher on ${watchDir}`);
+  const watcher = chokidar.watch(watchDir, {
+    ignored: (path, stats) => {
+      if (path.includes(DEFAULT_METADATA_DIR_NAME)) {
+        return true;
+      }
+      return stats?.isFile() && !extensions.some((ext) => path.endsWith(ext));
+    }
+  });
+  watcher.on('add', (path) => generateMetadata(path, excludePatternInGlob));
+  watcher.on('change', (path) => generateMetadata(path, excludePatternInGlob));
+  return watcher;
+};
+
+const customPlugin = (): PluginOption => {
+  return {
+    name: 'configure-server',
+    configureServer(server) {
+      server.middlewares.use('/.atomic-state-canvas', async (req, res) => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        try {
+          const files = await fs.readdir(DEFAULT_METADATA_DIR_NAME);
+          const data = await Promise.all(
+            files.map(async (f) =>
+              JSON.parse(await fs.readFile(path.join(DEFAULT_METADATA_DIR_NAME, f), 'utf-8'))
+            )
+          );
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(data));
+        } catch (err) {
+          console.error(err);
+          res.end(JSON.stringify([]));
+        }
+      });
+    }
+  };
+};
+
+export interface LaunchViewerOptions {
+  port?: number;
+  watchDir?: string;
+  isDev?: boolean;
+}
+
+export interface LaunchViewerResult {
+  server: ViteDevServer;
+  port: number;
+  url: string;
+}
+
+export async function launchViewer(options?: LaunchViewerOptions): Promise<LaunchViewerResult> {
+  const config: IAscConfig = await loadConfig(explorer);
+  const isDev = options?.isDev ?? process.argv.includes('--dev');
+  const {
+    port = options?.port ?? DEFAULT_PORT,
+    watchDir = options?.watchDir ?? path.resolve(process.cwd(), DEFAULT_WATCH_DIR),
+    extensions = DEFAULT_EXTENSIONS,
+    excludePatternInGlob
+  } = config;
+  const viewerPath = isDev
+    ? path.resolve(process.cwd(), 'apps/asc-viewer')
+    : path.resolve(__dirname, 'asc-viewer');
+
+  const server = await createServer({
+    root: viewerPath,
+    server: {
+      port
+    },
+    plugins: [customPlugin()]
+  });
+
+  watchAndGenerateMetadata({ watchDir, extensions, excludePatternInGlob });
+
+  await server.listen();
+
+  const actualPort = server.config.server.port ?? port;
+  const url = `http://localhost:${actualPort}`;
+
+  return {
+    server,
+    port: actualPort,
+    url
+  };
+}

--- a/apps/asc-viewer-cli/src/mcp/viewer.ts
+++ b/apps/asc-viewer-cli/src/mcp/viewer.ts
@@ -87,14 +87,14 @@ const customPlugin = (): PluginOption => {
 };
 
 export interface LaunchViewerOptions {
+  isDev?: boolean;
   port?: number;
   watchDir?: string;
-  isDev?: boolean;
 }
 
 export interface LaunchViewerResult {
-  server: ViteDevServer;
   port: number;
+  server: ViteDevServer;
   url: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,7 @@
         "three": "^0.175.0",
         "tslib": "^2.3.0",
         "tw-animate-css": "^1.2.7",
-        "zod": "^3.23.0",
-        "zod-to-json-schema": "^3.24.0"
+        "zod": "^4.1.13"
       },
       "devDependencies": {
         "@anolilab/multi-semantic-release": "^3.2.2",
@@ -31152,9 +31151,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.0.tgz",
+      "integrity": "sha512-Bd5fw9wlIhtqCCxotZgdTOMwGm1a0u75wARVEY9HMs1X17trvA/lMi4+MGK5EUfYkXVTbX8UDiDKW4OgzHVUZw==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "apps/asc-viewer-cli/**"
       ],
       "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "@radix-ui/react-dialog": "^1.1.10",
         "@radix-ui/react-separator": "^1.1.4",
         "@radix-ui/react-slot": "^1.2.0",
@@ -38,7 +40,9 @@
         "tailwind-merge": "^3.2.0",
         "three": "^0.175.0",
         "tslib": "^2.3.0",
-        "tw-animate-css": "^1.2.7"
+        "tw-animate-css": "^1.2.7",
+        "zod": "^3.23.0",
+        "zod-to-json-schema": "^3.24.0"
       },
       "devDependencies": {
         "@anolilab/multi-semantic-release": "^3.2.2",
@@ -2330,6 +2334,13 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -4241,6 +4252,303 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
+      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
+      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
@@ -11311,7 +11619,6 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -11445,7 +11752,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -11478,7 +11784,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -11695,7 +12000,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-ify": {
@@ -12475,7 +12779,6 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
       "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -12500,7 +12803,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -12510,7 +12812,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -12523,7 +12824,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -12668,7 +12968,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -12750,7 +13049,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -12764,7 +13062,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -13295,7 +13592,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -13308,7 +13604,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13425,7 +13720,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13435,7 +13729,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookies": {
@@ -13472,6 +13765,19 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/corser": {
       "version": "2.0.1",
@@ -13550,7 +13856,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -14040,7 +14345,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -14276,7 +14580,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -14296,7 +14599,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -14546,7 +14848,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -14618,7 +14919,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -14685,7 +14985,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -15002,7 +15301,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15012,7 +15310,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15057,7 +15354,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -15167,7 +15463,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -15579,7 +15874,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15610,6 +15904,27 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -15765,8 +16080,8 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -15808,11 +16123,25 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -15822,7 +16151,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/exsolve": {
@@ -15880,7 +16208,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -15945,7 +16272,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16174,7 +16500,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -16193,7 +16518,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -16203,7 +16527,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-file-up": {
@@ -16434,7 +16757,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16458,7 +16780,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16597,7 +16918,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16694,7 +17014,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -16738,7 +17057,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -17002,7 +17320,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17149,7 +17466,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17178,7 +17494,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -17348,7 +17663,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -17670,7 +17984,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -17735,7 +18048,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -18093,6 +18405,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -18311,7 +18629,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
@@ -19349,6 +19666,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jotai": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.16.0.tgz",
@@ -19477,7 +19803,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -20615,7 +20940,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -20632,7 +20956,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -20691,7 +21014,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -20724,7 +21046,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -20761,7 +21082,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -20774,7 +21094,6 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -20784,7 +21103,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -20797,7 +21115,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -20940,7 +21257,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
@@ -21016,7 +21332,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23649,7 +23964,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -23747,7 +24061,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -23760,7 +24073,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -24191,7 +24503,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -24228,7 +24539,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24269,7 +24579,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -24352,6 +24661,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "@napi-rs/nice": "^1.0.1"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-conf": {
@@ -24678,7 +24996,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -24739,7 +25056,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -24840,7 +25156,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -24850,7 +25165,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -24866,7 +25180,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -25474,7 +25787,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -25667,6 +25979,32 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
@@ -25722,7 +26060,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25778,7 +26115,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -26157,7 +26493,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.1.tgz",
       "integrity": "sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -26182,7 +26517,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -26192,14 +26526,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -26216,7 +26548,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -26236,7 +26567,6 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -26252,7 +26582,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -26262,14 +26591,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/serve-static/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -26286,7 +26613,6 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -26311,7 +26637,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -26321,7 +26646,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -26380,14 +26704,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -26400,7 +26722,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26410,7 +26731,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -26430,7 +26750,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -26447,7 +26766,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -26466,7 +26784,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -26835,7 +27152,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -28073,7 +28389,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -28887,7 +29202,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -29211,7 +29525,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -29341,7 +29654,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -29394,7 +29706,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -30360,7 +30671,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -30536,7 +30846,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -30840,6 +31149,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
+      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "viewer-cli:dev": "npx nx dev asc-viewer-cli",
     "build:viewer-cli": "npx nx run-many --target=build --projects=asc-viewer,asc-viewer-cli",
     "build:all": "npx nx run-many --target=build --projects=asc-viewer,asc-viewer-cli,asc-cli",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "npx vitest run",
+    "test:watch": "npx vitest",
+    "test:ui": "npx vitest --ui",
     "lint": "npx nx run-many --target=lint",
     "semantic-release:dry-run": "semantic-release --dryRun",
     "semantic-release": "semantic-release",
@@ -45,6 +47,8 @@
   "license": "MIT",
   "description": "This is a mono-repository that contains a collection of applications for analyzing and visualizing atomic state relationships.",
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "@radix-ui/react-dialog": "^1.1.10",
     "@radix-ui/react-separator": "^1.1.4",
     "@radix-ui/react-slot": "^1.2.0",
@@ -70,7 +74,9 @@
     "tailwind-merge": "^3.2.0",
     "three": "^0.175.0",
     "tslib": "^2.3.0",
-    "tw-animate-css": "^1.2.7"
+    "tw-animate-css": "^1.2.7",
+    "zod": "^3.23.0",
+    "zod-to-json-schema": "^3.24.0"
   },
   "devDependencies": {
     "@anolilab/multi-semantic-release": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "three": "^0.175.0",
     "tslib": "^2.3.0",
     "tw-animate-css": "^1.2.7",
-    "zod": "^3.23.0",
-    "zod-to-json-schema": "^3.24.0"
+    "zod": "^4.1.13"
   },
   "devDependencies": {
     "@anolilab/multi-semantic-release": "^3.2.2",


### PR DESCRIPTION
Add Model Context Protocol (MCP) support to asc-viewer-cli, enabling AI assistants to analyze Recoil state and launch visualizations.

New MCP tools:
- analyze_state: Generate dependency graph from entry file/variable
- find_cycles: Detect cyclic dependencies and self-references
- list_atoms: List all atoms/selectors in a file with dependencies
- launch_viewer: Start the visualization server

Changes:
- Add mcp subcommand to CLI (asc-viewer mcp)
- Refactor CLI to use Commander.js with subcommands
- Add @modelcontextprotocol/sdk, zod, zod-to-json-schema dependencies
- Update documentation with MCP setup and configuration options